### PR TITLE
Add additional colors

### DIFF
--- a/packages/theme/src/index.js
+++ b/packages/theme/src/index.js
@@ -19,6 +19,8 @@ const colors = {
   green: '#33d6a6',
   cyan: '#5bc0de',
   blue: '#338eda',
+  purple: '#800080',
+  brown: '#8b4513',
 
   twitter: '#1da1f2',
   facebook: '#3b5998',


### PR DESCRIPTION
Me realizing I didn't have the colors for philly pride: 👁👄👁
Me realizing that Hack Club open sources their design tools:  👁⭕️👁

Here's some screenshots of the colors in action — I think they look pretty good but let me know if the values need tweaking!
<img width="874" alt="Screen Shot 2020-06-16 at 11 37 25 PM" src="https://user-images.githubusercontent.com/7117993/84852267-6baf7f80-b02a-11ea-9221-46dcd20888a5.png">
<img width="699" alt="Screen Shot 2020-06-16 at 11 37 51 PM" src="https://user-images.githubusercontent.com/7117993/84852270-6d794300-b02a-11ea-800a-622593a55c24.png">
<img width="1440" alt="Screen Shot 2020-06-10 at 12 40 34 AM" src="https://user-images.githubusercontent.com/7117993/84852274-6eaa7000-b02a-11ea-9d47-cfe065b533f2.png">


