### PR TITLE
Comment out :focus,:hover text-decoration-style declaration

### DIFF
--- a/packages/theme/src/index.ts
+++ b/packages/theme/src/index.ts
@@ -393,9 +393,12 @@ const theme = {
       color: 'primary',
       textDecoration: 'underline',
       textUnderlinePosition: 'under',
-      ':focus,:hover': {
-        textDecorationStyle: 'wavy'
-      }
+      /* 
+       * Temporarily removed due to lack of proper support for text-decoration style
+        ':focus,:hover': {
+          textDecorationStyle: 'wavy'
+        }
+       */
     },
     pre: {
       fontFamily: 'monospace',

--- a/packages/theme/src/index.ts
+++ b/packages/theme/src/index.ts
@@ -392,7 +392,7 @@ const theme = {
     a: {
       color: 'primary',
       textDecoration: 'underline',
-      textUnderlinePosition: 'under',
+      textUnderlinePosition: 'under'
       /* 
        * Temporarily removed due to lack of proper support for text-decoration style
         ':focus,:hover': {


### PR DESCRIPTION
See 02ed382 for an alternative, hacky solution and explanation for why this is needed. See also initial bug disc in hackclub/v3#20 and Chromium issue https://bugs.chromium.org/p/chromium/issues/detail?id=991310#c5

Hopefully will be fixed in a few Chromium releases, and this can be reverted.