### PR TITLE
Re-implement red theme color

### DIFF
--- a/packages/meta/src/index.js
+++ b/packages/meta/src/index.js
@@ -10,7 +10,6 @@ const Meta = ({
   description,
   image,
   color = '#ec3750',
-  safariColor = '#17171d',
   manifest = 'https://assets.hackclub.com/favicons/site.webmanifest',
   children
 }) => (
@@ -40,7 +39,7 @@ const Meta = ({
         <meta key="tw_img" name="twitter:image" content={image} />
       </React.Fragment>
     )}
-    <meta key="theme_color" name="theme-color" content={safariColor} />
+    <meta key="theme_color" name="theme-color" content={color} />
     <meta key="tile_color" name="msapplication-TileColor" content={color} />
     <link
       key="safari_icon"

--- a/packages/meta/test/__snapshots__/index.js.snap
+++ b/packages/meta/test/__snapshots__/index.js.snap
@@ -30,7 +30,7 @@ exports[`Meta renders 1`] = `
     name="twitter:title"
   />
   <meta
-    content="#17171d"
+    content="#ec3750"
     name="theme-color"
   />
   <meta
@@ -96,7 +96,7 @@ exports[`Meta renders children 1`] = `
     name="twitter:title"
   />
   <meta
-    content="#17171d"
+    content="#ec3750"
     name="theme-color"
   />
   <meta
@@ -166,7 +166,7 @@ exports[`Meta renders custom color 1`] = `
     name="twitter:title"
   />
   <meta
-    content="#17171a"
+    content="#0069ff"
     name="theme-color"
   />
   <meta
@@ -232,7 +232,7 @@ exports[`Meta renders custom title 1`] = `
     name="twitter:title"
   />
   <meta
-    content="#17171d"
+    content="#ec3750"
     name="theme-color"
   />
   <meta
@@ -310,7 +310,7 @@ exports[`Meta renders image 1`] = `
     name="twitter:image"
   />
   <meta
-    content="#17171d"
+    content="#ec3750"
     name="theme-color"
   />
   <meta

--- a/packages/meta/test/index.js
+++ b/packages/meta/test/index.js
@@ -42,13 +42,10 @@ test('Meta renders image', () => {
 })
 
 test('Meta renders custom color', () => {
-  const safariColor = '#17171a'
   const color = '#0069ff'
-  const { container } = render(<Meta safariColor={safariColor} color={color} />)
+  const { container } = render(<Meta color={color} />)
   expect(
-    container.querySelector(
-      `meta[name="theme-color"][content="${safariColor}"]`
-    )
+    container.querySelector(`meta[name="theme-color"][content="${color}"]`)
   ).toBeTruthy()
   expect(container).toMatchSnapshot()
 })


### PR DESCRIPTION
Reverts hackclub/theme#30, as per Slack discussion :)

(Also, `theme-color` is a web standard, Safari is just one of several browsers that implements it, including Chrome for Android, the top mobile browser globally, & Vivaldi, so avoid referring to it as “Safari color” :+1:)